### PR TITLE
Update conferences.yml

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -55,8 +55,8 @@
   timezone: EDT
   date: November 08-11
   place: New York, USA
-  comment: Notification - July 3, 2026.
-  tags: [THEORY, CNF, COREAS, EXP]
+  comment: Notification - July 3.
+  tags: [THEORY, CNF, COREAS]
 
 - name: IEEE INFOCOM
   description: IEEE International Conference on Computer Communications

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -51,10 +51,11 @@
   description: IEEE Symposium on Foundations of Computer Science
   year: 2026
   link: https://focs.computer.org/2026/
-  deadline: ["2026-04-02 19:59"]
+  deadline: ["2026-04-01 16:59"]
+  timezone: EDT
   date: November 08-11
   place: New York, USA
-  comment: Notification - August 01.
+  comment: Notification - July 3, 2026.
   tags: [THEORY, CNF, COREAS, EXP]
 
 - name: IEEE INFOCOM


### PR DESCRIPTION
the ddl and notification time of FOCS'26 is wrong, just updated, details can be found in https://focs.computer.org/2026/call-for-papers-2/