### PR TITLE
Add: PKC 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -468,6 +468,16 @@
   comment: Early Reject - December 16. Notification - February 13.
   tags: [THEORY, CNF, COREB]
 
+- name: PKC
+  year: 2027
+  link: "https://pkc.iacr.org/2027/"
+  deadline: ["2026-08-03 23:59"]
+  rebut: "Oct 5-10, 2026"
+  date: "March 1-4, 2027"
+  place: "Taipei, Taiwan"
+  comment: "First round notification - September 28, Final notification - November 19"
+  tags: [THEORY, CNF, COREB]
+
 - name: SAC
   description: Conference on Selected Areas in Cryptography
   year: 2026


### PR DESCRIPTION
## PKC 2027 — insert

| Field | Value |
|---|---|
| Source URL | [https://pkc.iacr.org/2027/](https://pkc.iacr.org/2027/) |
| Posted in | [Telegram message](https://t.me/mpc_deadlines/13) |
| Action | `insert` |
| Tags | `THEORY, CNF, COREB` |
| Deadline(s) | `2026-08-03 23:59` |
| Date | `March 1-4, 2027` |
| Place | `Taipei, Taiwan` |

### YAML preview
```yaml
- name: PKC
  year: 2027
  link: "https://pkc.iacr.org/2027/"
  deadline: ["2026-08-03 23:59"]
  rebut: "Oct 5-10, 2026"
  date: "March 1-4, 2027"
  place: "Taipei, Taiwan"
  comment: "First round notification - September 28, Final notification - November 19"
  tags: [THEORY, CNF, COREB]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
