### PR TITLE
Add: PKC 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -459,13 +459,13 @@
   
 - name: PKC
   description: International Conference on Practice and Theory of Public Key Cryptography
-  year: 2026
-  link: https://pkc.iacr.org/2026/
-  deadline: ["2025-10-24 23:59"]
-  rebut: December 16-23
-  date: May 25-28
-  place: West Palm Beach, USA
-  comment: Early Reject - December 16. Notification - February 13.
+  year: 2027
+  link: "https://pkc.iacr.org/2027/"
+  deadline: ["2026-08-03 23:59"]
+  rebut: Oct 5-12
+  date: March 1-4
+  place: Taipei, Taiwan
+  comment: First round notification - September 28. Final notification - November 19.
   tags: [THEORY, CNF, COREB]
 
 - name: SAC


### PR DESCRIPTION
## PKC 2027 — insert (removed 1 stale entry)

| Field | Value |
|---|---|
| Source URL | [https://pkc.iacr.org/2027/](https://pkc.iacr.org/2027/) |
| Posted in | [Telegram message](https://t.me/mpc_deadlines/15) |
| Action | `insert (removed 1 stale entry)` |
| Tags | `THEORY, CNF, COREB` |
| Deadline(s) | `2026-08-03 23:59` |
| Date | `March 1-4` |
| Place | `Taipei, Taiwan` |

### YAML preview
```yaml
- name: PKC
  description: International Conference on Practice and Theory of Public Key Cryptography
  year: 2027
  link: "https://pkc.iacr.org/2027/"
  deadline: ["2026-08-03 23:59"]
  rebut: Oct 5-12
  date: March 1-4
  place: Taipei, Taiwan
  comment: First round notification - September 28. Final notification - November 19.
  tags: [THEORY, CNF, COREB]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
