### PR TITLE
Update: WAHC 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -888,16 +888,16 @@
   tags: [PRACT, APPLIED, WK]
 
 - name: WAHC
-  description: Workshop on Encrypted Computing & Applied Homomorphic Cryptography
+  description: "14th Workshop on Encrypted Computing & Applied Homomorphic Cryptography"
   year: 2026
-  link: https://homomorphicencryption.org/wahc-2026/
-  deadline: ["2026-06-27 23:59"]
+  link: "https://homomorphicencryption.org/wahc-2026-14th-workshop-on-encrypted-computing-applied-homomorphic-cryptography/"
+  deadline: ["2026-06-20 23:59"]
   date: November 15
   place: The Hague, Netherlands
-  comment: Notification - August 08. Has proceedings.
+  comment: Notification - TBA. Has proceedings.
   conference: ACM CCS.
-  tags: [APPLIED, WK, EXP]
-  
+  tags: [APPLIED, WK]
+
 - name: WPES
   description: Workshop on Privacy in the Electronic Society
   year: 2026


### PR DESCRIPTION
## WAHC 2026 — upgrade (EXP → FULL)

| Field | Value |
|---|---|
| Source URL | [https://homomorphicencryption.org/wahc-2026-14th-workshop-on-encrypted-computing-applied-homomorphic-cryptography/](https://homomorphicencryption.org/wahc-2026-14th-workshop-on-encrypted-computing-applied-homomorphic-cryptography/) |
| Posted in | Telegram channel |
| Action | `upgrade (EXP → FULL)` |
| Tags | `APPLIED, WK` |
| Deadline(s) | `2026-06-20 23:59` |
| Date | `November 15` |
| Place | `The Hague, Netherlands` |

### YAML preview
```yaml
- name: WAHC
  description: "14th Workshop on Encrypted Computing & Applied Homomorphic Cryptography"
  year: 2026
  link: "https://homomorphicencryption.org/wahc-2026-14th-workshop-on-encrypted-computing-applied-homomorphic-cryptography/"
  deadline: ["2026-06-20 23:59"]
  date: November 15
  place: The Hague, Netherlands
  comment: Notification - TBA. Has proceedings.
  conference: ACM CCS
  tags: [APPLIED, WK]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
