### PR TITLE
Update: WPES 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -917,7 +917,7 @@
   deadline: ["2026-07-17 23:59"]
   date: November 16
   place: The Hague, Netherlands
-  comment: Notification to authors - September 4. Camera-ready due - September 17.
+  comment: Notification - September 4. Has proceedings.
   conference: ACM CCS.
   tags: [PRACT, WK]
 

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -913,14 +913,14 @@
 - name: WPES
   description: Workshop on Privacy in the Electronic Society
   year: 2026
-  link: http://jianying.space/WPES2026/
-  deadline: ["2026-07-07 23:59"]
-  date: November 15
+  link: "https://wpes2026.github.io"
+  deadline: ["2026-07-17 23:59"]
+  date: November 16
   place: The Hague, Netherlands
-  comment: Notification - August 16. Has proceedings.
+  comment: Notification to authors - September 4. Camera-ready due - September 17.
   conference: ACM CCS.
-  tags: [PRACT, WK, EXP]
-  
+  tags: [PRACT, WK]
+
 # Posters
 
 - name: ACM ASIACCS


### PR DESCRIPTION
## WPES 2026 — upgrade (EXP → FULL)

| Field | Value |
|---|---|
| Source URL | [https://wpes2026.github.io](https://wpes2026.github.io) |
| Posted in | Telegram channel |
| Action | `upgrade (EXP → FULL)` |
| Tags | `PRACT, WK` |
| Deadline(s) | `2026-07-17 23:59` |
| Date | `November 16` |
| Place | `The Hague, Netherlands` |

### YAML preview
```yaml
- name: WPES
  description: Workshop on Privacy in the Electronic Society
  year: 2026
  link: "https://wpes2026.github.io"
  deadline: ["2026-07-17 23:59"]
  date: November 16
  place: The Hague, Netherlands
  comment: Notification to authors - September 4. Camera-ready due - September 17.
  conference: ACM CCS
  tags: [PRACT, WK]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
