### PR TITLE
Update: EUROCRYPT 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -39,12 +39,12 @@
 - name: EUROCRYPT
   description: European Cryptology Conference
   year: 2027
-  link: "https://eurocrypt.iacr.org/2027/"
+  link: "https://eurocrypt.iacr.org/2027/callforpapers.php"
   deadline: ["2026-09-17 23:59"]
   date: April 11-15
   place: Eindhoven
   comment: "Early Reject Notification: November 20, 2026, Notification: January 18, 2027"
-  tags: [THEORY, CNF, COREAS, EXPCFP]
+  tags: [THEORY, CNF, COREAS]
 
 - name: IEEE FOCS
   description: IEEE Symposium on Foundations of Computer Science

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -43,7 +43,7 @@
   deadline: ["2026-09-17 23:59"]
   date: April 11-15
   place: Eindhoven
-  comment: "Early Reject Notification: November 20, 2026, Notification: January 18, 2027"
+  comment: "Early Reject Notification: November 30, Notification: January 18, 2027"
   tags: [THEORY, CNF, COREAS]
 
 - name: IEEE FOCS


### PR DESCRIPTION
## EUROCRYPT 2027 — upgrade (EXPCFP → FULL)

| Field | Value |
|---|---|
| Source URL | [https://eurocrypt.iacr.org/2027/callforpapers.php](https://eurocrypt.iacr.org/2027/callforpapers.php) |
| Posted in | [Telegram message](https://t.me/mpc_deadlines/27) |
| Action | `upgrade (EXPCFP → FULL)` |
| Tags | `THEORY, CNF, COREAS` |
| Deadline(s) | `2026-09-17 23:59` |
| Date | `April 11-15` |
| Place | `Eindhoven` |

### YAML preview
```yaml
- name: EUROCRYPT
  description: European Cryptology Conference
  year: 2027
  link: "https://eurocrypt.iacr.org/2027/callforpapers.php"
  deadline: ["2026-09-17 23:59"]
  date: April 11-15
  place: Eindhoven
  comment: "Early Reject Notification: November 20, 2026, Notification: January 18, 2027"
  tags: [THEORY, CNF, COREAS]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
