### PR TITLE
Update: PKC 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -464,7 +464,7 @@
   rebut: Oct 5-12
   date: March 1-4
   place: Taipei, Taiwan
-  comment: First round notification - September 28. Final notification - November 19.
+  comment: CFP yet to be announced
   tags: [THEORY, CNF, COREB]
 
 - name: SAC


### PR DESCRIPTION
## PKC 2027 — upgrade (FULL → EXP)

| Field | Value |
|---|---|
| Source URL | [https://pkc.iacr.org/2027/](https://pkc.iacr.org/2027/) |
| Posted in | [Telegram message](https://t.me/mpc_deadlines/29) |
| Action | `upgrade (FULL → EXP)` |
| Tags | `THEORY, CNF, EXP, COREB` |
| Deadline(s) | `TBD` |
| Date | `TBD` |
| Place | `TBD` |

### YAML preview
```yaml
- name: PKC
  description: International Conference on Practice and Theory of Public Key Cryptography
  year: 2027
  link: "https://pkc.iacr.org/2027/"
  deadline: ["TBD"]
  comment: CFP yet to be announced
  tags: [THEORY, CNF, EXP, COREB]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
