### PR TITLE
Update: IEEE INFOCOM 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -59,14 +59,14 @@
 
 - name: IEEE INFOCOM
   description: IEEE International Conference on Computer Communications
-  year: 2027  
-  link: https://infocom2027.ieee-infocom.org
-  abdeadline: July 17
-  deadline: ["2026-07-24 23:59"]
-  date: May 17-20
-  place: Honolulu, Hawai
+  year: 2027
+  link: "https://infocom2027.ieee-infocom.org"
+  abdeadline: July 24
+  deadline: ["2026-07-31 23:59"]
+  date: May 24-27
+  place: Honolulu, HI, USA
   comment: Notification - December 01.
-  tags: [PRACT, APPLIED, CNF, COREAS, EXPCFP]
+  tags: [PRACT, APPLIED, CNF, COREAS]
 
 - name: IEEE S&P (Oakland)
   description: IEEE Symposium on Security and Privacy

--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -65,7 +65,7 @@
   deadline: ["2026-07-31 23:59"]
   date: May 24-27
   place: Honolulu, HI, USA
-  comment: Notification - December 01.
+  comment: Notification - December 08.
   tags: [PRACT, APPLIED, CNF, COREAS]
 
 - name: IEEE S&P (Oakland)


### PR DESCRIPTION
## IEEE INFOCOM 2027 — upgrade (EXPCFP → FULL)

| Field | Value |
|---|---|
| Source URL | [https://infocom2027.ieee-infocom.org](https://infocom2027.ieee-infocom.org) |
| Posted in | Telegram channel |
| Action | `upgrade (EXPCFP → FULL)` |
| Tags | `PRACT, APPLIED, CNF, COREAS` |
| Deadline(s) | `2026-07-31 23:59` |
| Date | `May 24-27` |
| Place | `Honolulu, HI, USA` |

### YAML preview
```yaml
- name: IEEE INFOCOM
  description: IEEE International Conference on Computer Communications
  year: 2027
  link: "https://infocom2027.ieee-infocom.org"
  abdeadline: July 24
  deadline: ["2026-07-31 23:59"]
  date: May 24-27
  place: Honolulu, HI, USA
  tags: [PRACT, APPLIED, CNF, COREAS]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
