### PR TITLE
Add: IEEE Security & Privacy 2027

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -329,6 +329,14 @@
   comment: Notification - April 02.
   tags: [THEORY, PRACT, CNF, COREA]
   
+- name: "IEEE Security & Privacy"
+  description: "IEEE Security & Privacy"
+  year: 2027
+  link: "https://www.computer.org/digital-library/magazines/sp/cfp-one-decade-gdpr-challenges"
+  deadline: ["2026-12-01 23:59"]
+  comment: Special Issue on One Decade of GDPR
+  tags: [APPLIED, PRACT, JRN, COREA]
+
 - name: ITCS
   description: Innovations in Theoretical Computer Science
   year: 2027


### PR DESCRIPTION
## IEEE Security & Privacy 2027 — insert

| Field | Value |
|---|---|
| Source URL | [https://www.computer.org/digital-library/magazines/sp/cfp-one-decade-gdpr-challenges](https://www.computer.org/digital-library/magazines/sp/cfp-one-decade-gdpr-challenges) |
| Posted in | Telegram channel |
| Action | `insert` |
| Tags | `APPLIED, PRACT, JRN, COREA` |
| Deadline(s) | `2026-12-01 23:59` |
| Date | `TBD` |
| Place | `TBD` |

### YAML preview
```yaml
- name: "IEEE Security & Privacy"
  description: "IEEE Security & Privacy"
  year: 2027
  link: "https://www.computer.org/digital-library/magazines/sp/cfp-one-decade-gdpr-challenges"
  deadline: ["2026-12-01 23:59"]
  comment: Special Issue on One Decade of GDPR
  tags: [APPLIED, PRACT, JRN, COREA]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
