### PR TITLE
Add: Workshop on Cryptography for Bitcoin 2026

### DIFF
--- a/_data/conferences.yml
+++ b/_data/conferences.yml
@@ -910,6 +910,15 @@
   conference: ACM CCS.
   tags: [APPLIED, WK]
 
+- name: Workshop on Cryptography for Bitcoin
+  description: Workshop on Cryptography for Bitcoin
+  year: 2026
+  link: "https://bitcoin-cryptography-workshop.github.io/"
+  date: July 31
+  place: Frances C. Arrillaga Alumni Center, Stanford, CA
+  conference: Science of Blockchain Conference 2026
+  tags: [THEORY, PRACT, APPLIED, WK]
+
 - name: WPES
   description: Workshop on Privacy in the Electronic Society
   year: 2026


### PR DESCRIPTION
## Workshop on Cryptography for Bitcoin 2026 — insert

| Field | Value |
|---|---|
| Source URL | [https://bitcoin-cryptography-workshop.github.io/](https://bitcoin-cryptography-workshop.github.io/) |
| Posted in | Telegram channel |
| Action | `insert` |
| Tags | `THEORY, PRACT, APPLIED, WK` |
| Deadline(s) | `TBD` |
| Date | `July 31` |
| Place | `Frances C. Arrillaga Alumni Center, Stanford, CA` |

### YAML preview
```yaml
- name: Workshop on Cryptography for Bitcoin
  description: Workshop on Cryptography for Bitcoin
  year: 2026
  link: "https://bitcoin-cryptography-workshop.github.io/"
  date: July 31
  place: Frances C. Arrillaga Alumni Center, Stanford, CA
  conference: Science of Blockchain Conference 2026
  tags: [THEORY, PRACT, APPLIED, WK]
```

### Before merging, please verify
- [ ] Conference name and description are correct
- [ ] All deadline(s) are accurate and in the right timezone (default AoE / UTC-12)
- [ ] Tags are appropriate (domain, type, CORE rank)
- [ ] Entry is in the correct alphabetical position within its CORE group
- [ ] `comment` field is accurate (notification dates, rounds, etc.)
- [ ] For EXP/EXPCFP entries: placeholder values will be updated once the CFP is live

*🤖 Opened automatically by the [MPC Deadlines Telegram bot](https://t.me/mpc_deadlines)*
